### PR TITLE
Auto-retry API calls for Network exception

### DIFF
--- a/character/character-interactors/src/main/java/com/example/character_interactors/FlowExt.kt
+++ b/character/character-interactors/src/main/java/com/example/character_interactors/FlowExt.kt
@@ -1,0 +1,30 @@
+package com.example.character_interactors
+
+import com.example.core.ApiException
+import com.example.core.DataState
+import com.example.core.toApiException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.retryWhen
+import kotlin.coroutines.CoroutineContext
+
+fun <T> Flow<DataState<T>>.safeDataStateFlow(coroutineContext: CoroutineContext = Dispatchers.IO, autoRetry: Boolean = true): Flow<DataState<T>> =
+    retryWhen { cause, attempt -> autoRetry && canRetry(cause, attempt) }
+        .catch { (it as? Exception)?.toApiException()?.let { exception -> emit(DataState.Error(exception)) } }
+        .flowOn(coroutineContext)
+        .onStart { emit(DataState.Loading()) }
+
+private suspend fun canRetry(cause: Throwable, attempt: Long, retries: Int = 3, delayBetweenRetries: Long = 500): Boolean {
+    val isNetworkException = (cause as? Exception)?.toApiException() == ApiException.Network
+    val canRetry = isNetworkException && attempt < retries
+    return if (canRetry) {
+        delay(delayBetweenRetries)
+        true
+    } else {
+        false
+    }
+}

--- a/character/character-interactors/src/main/java/com/example/character_interactors/GetCharacterFromCache.kt
+++ b/character/character-interactors/src/main/java/com/example/character_interactors/GetCharacterFromCache.kt
@@ -3,24 +3,18 @@ package com.example.character_interactors
 import com.example.character_datasource.cache.CharactersCache
 import com.example.character_domain.Character
 import com.example.core.DataState
-import com.example.core.toApiException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
 class GetCharacterFromCache(private val cache: CharactersCache) {
 
     fun invoke(id: Int): Flow<DataState<Character>> = flow {
-        try {
-            emit(DataState.Loading())
-            val cachedCharacter = cache.getCharacter(id)
+        val cachedCharacter = cache.getCharacter(id)
 
-            if (cachedCharacter != null) {
-                emit(DataState.Success(data = cachedCharacter))
-            } else {
-                throw Exception("Character with id $id doesn't exist in cache.")
-            }
-        } catch (e: Exception) {
-            emit(DataState.Error(e.toApiException()))
+        if (cachedCharacter != null) {
+            emit(DataState.Success(data = cachedCharacter))
+        } else {
+            throw Exception("Character with id $id doesn't exist in cache.")
         }
-    }
+    }.safeDataStateFlow()
 }

--- a/character/character-interactors/src/main/java/com/example/character_interactors/GetCharacters.kt
+++ b/character/character-interactors/src/main/java/com/example/character_interactors/GetCharacters.kt
@@ -4,8 +4,6 @@ import com.example.character_datasource.cache.CharactersCache
 import com.example.character_datasource.network.CharactersService
 import com.example.character_domain.Character
 import com.example.core.DataState
-import com.example.core.toApiException
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
 class GetCharacters(
@@ -13,28 +11,23 @@ class GetCharacters(
     private val cache: CharactersCache
 ) {
 
-    fun invoke(): Flow<DataState<List<Character>>> = flow {
-        try {
-            emit(DataState.Loading())
-            val characters = mutableListOf<Character>()
+    fun invoke() = flow<DataState<List<Character>>> {
+        val characters = mutableListOf<Character>()
 
-            val dataState = getCharacters(service)
-            if (dataState is DataState.Success) {
-                characters.addAll(dataState.data)
-            }
-
-            cache.insertCharacters(characters)
-            val cachedCharacters = cache.getAllCharacters()
-
-            if (cachedCharacters.isNotEmpty()) {
-                emit(DataState.Success(data = cachedCharacters))
-            } else {
-                throw dataState.cause as Exception
-            }
-        } catch (e: Exception) {
-            emit(DataState.Error(e.toApiException()))
+        val dataState = getCharacters(service)
+        if (dataState is DataState.Success) {
+            characters.addAll(dataState.data)
         }
-    }
+
+        cache.insertCharacters(characters)
+        val cachedCharacters = cache.getAllCharacters()
+
+        if (cachedCharacters.isNotEmpty()) {
+            emit(DataState.Success(data = cachedCharacters))
+        } else {
+            throw dataState.cause as Exception
+        }
+    }.safeDataStateFlow()
 
     /**
      * getCharacters() method returns 60 characters from API. This API automatically limits each API response to 20 characters only and since pagination is not in place yet, this method loads characters till page 3.

--- a/core/src/main/java/com/example/core/DataState.kt
+++ b/core/src/main/java/com/example/core/DataState.kt
@@ -9,5 +9,5 @@ sealed class DataState<T>(open val data: T? = null, open val cause: ApiException
 sealed class ApiException(open val statusCode: Int = -1, open val errorMsg: String) : Exception(errorMsg) {
     data class Generic(override val errorMsg: String = "Something went wrong. Please try again!") : ApiException(errorMsg = errorMsg)
     data class HttpError(override val statusCode: Int, override val errorMsg: String = "Request could not be processed! Code :$statusCode") : ApiException(errorMsg = errorMsg)
-    object Network : ApiException(errorMsg = "Failed to connect. Please try again!")
+    data object Network : ApiException(errorMsg = "Failed to connect. Please try again!")
 }


### PR DESCRIPTION
- Use Flow's `catch { }` to catch exceptions instead of `try { } catch { }` block.
- Retry failed API calls if they get a [Network](https://github.com/shahzadansari/RickAndMorty/blob/02cb818efa02469028e29677eb57e995111e8fb7/core/src/main/java/com/example/core/DataState.kt#L12) exception.
- Emits Loading state immediately when Flow starts emitting value.
- Flows on `Dispatchers.IO` by default.

Uses Flow's [retryWhen { }](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.flow/retry-when.html) to retry API call 3 times if it had gotten a Network exception.

```
fun <T> Flow<DataState<T>>.safeDataStateFlow(coroutineContext: CoroutineContext = Dispatchers.IO, autoRetry: Boolean = true): Flow<DataState<T>> =
    retryWhen { cause, attempt -> autoRetry && canRetry(cause, attempt) }
        .catch { (it as? Exception)?.toApiException()?.let { exception -> emit(DataState.Error(exception)) } }
        .flowOn(coroutineContext)
        .onStart { emit(DataState.Loading()) }
```

Current implementation retries 3 times and only if it was a Network exception.
```
private suspend fun canRetry(cause: Throwable, attempt: Long, retries: Int = 3, delayBetweenRetries: Long = 500): Boolean {
    val isNetworkException = (cause as? Exception)?.toApiException() == ApiException.Network
    val canRetry = isNetworkException && attempt < retries
    return if (canRetry) {
        delay(delayBetweenRetries)
        true
    } else {
        false
    }
}
```