### PR TITLE
Enable launchSingleTop for CharacterDetailsScreen

### DIFF
--- a/app/src/main/java/com/example/modularized_rickandmortyapp/MainActivity.kt
+++ b/app/src/main/java/com/example/modularized_rickandmortyapp/MainActivity.kt
@@ -43,7 +43,9 @@ fun NavGraphBuilder.charactersListScreen(navController: NavController) {
         CharactersListScreen(
             state = viewModel.state,
             navigateToDetailScreen = { characterId ->
-                navController.navigate("${Screen.CharacterDetails.route}/$characterId")
+                navController.navigate("${Screen.CharacterDetails.route}/$characterId") {
+                    launchSingleTop = true
+                }
             },
             onTriggerEvent = {
                 viewModel.onTriggerEvent(it)


### PR DESCRIPTION
Fix for #22
Enabled `launchedSingleTop` while navigating to `CharacterDetailsScreen` so there will only be one instance of this destination (even if user taps very quickly on a `CharacterListItem`). More info on [launchSingleTop](https://developer.android.com/reference/kotlin/androidx/navigation/NavOptionsBuilder#launchSingleTop()).