### PR TITLE
Compose Lint Checks

### DIFF
--- a/character/ui-character-details/build.gradle.kts
+++ b/character/ui-character-details/build.gradle.kts
@@ -44,4 +44,6 @@ dependencies {
     implementation(libs.coil)
     implementation(libs.koin.android)
     implementation(libs.lifecycle.runtime.ktx)
+
+    lintChecks(libs.compose.lint.checks)
 }

--- a/character/ui-character-list/build.gradle.kts
+++ b/character/ui-character-list/build.gradle.kts
@@ -44,4 +44,6 @@ dependencies {
     implementation(libs.coil)
     implementation(libs.koin.android)
     implementation(libs.lifecycle.runtime.ktx)
+
+    lintChecks(libs.compose.lint.checks)
 }

--- a/components/build.gradle.kts
+++ b/components/build.gradle.kts
@@ -39,4 +39,6 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.bundles.compose)
     implementation(libs.lifecycle.runtime.ktx)
+
+    lintChecks(libs.compose.lint.checks)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ composeBom = "2024.01.00"
 composeMaterial3 = "1.2.0-rc01"
 composeNavigation = "2.7.6"
 composeUiToolingPreview = "1.6.0"
+composeLintChecks = "1.3.1"
 coreKtx = "1.12.0"
 coroutinesCore = "1.7.3"
 jsonSerialization = "1.6.2"
@@ -33,6 +34,7 @@ compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4
 compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview", version.ref = "composeUiToolingPreview" }
 compose-ui-util = { group = "androidx.compose.ui", name = "ui-util" }
+compose-lint-checks = { group = "com.slack.lint.compose", name = "compose-lint-checks", version.ref = "composeLintChecks" }
 koin-core = { group = "io.insert-koin", name = "koin-core", version.ref = "koin" }
 koin-android = { group = "io.insert-koin", name = "koin-android", version.ref = "koin" }
 koin-compose = { group = "io.insert-koin", name = "koin-androidx-compose", version.ref = "koinCompose" }


### PR DESCRIPTION
Found this really handy linter by Slack [**compose-lints**](https://slackhq.github.io/compose-lints/) which specifically checks for Compose components. These checks are to ensure that your composables don’t fall into common pitfalls that may be easy to miss in code reviews.

- Gives a reference link to read up more on a certain rule
- Allows suppressing that warning
- Gives suggestions to how a certain issue could be resolved

These rules are based on [**API Guidelines for @Composable components in Jetpack Compose**](https://github.com/androidx/androidx/blob/androidx-main/compose/docs/compose-component-api-guidelines.md).

![compose-lint-rules](https://github.com/shahzadansari/RickAndMorty/assets/43310446/0525ee25-1f42-48da-a3fb-8d82993b8d5b)